### PR TITLE
fix composer.json to allow easier installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description":"Extends the FAQ bundle in Contao. The bundle allows you to highlight very popular FAQ articles or your personal recommendations in the Contao frontend. It also introduces voting support for FAQ articles.",
   "keywords":["contao", "module", "extension", "faq", "helpful"],
   "type":"contao-bundle",
-  "license":"LGPL-3.0+",
+  "license":"LGPL-3.0-or-later",
   "authors":[
     {
       "name":"Helmut Schottmüller",
@@ -14,41 +14,39 @@
     "php": ">=5.6.0",
     "contao/core-bundle":"~4.4",
     "contao/faq-bundle": "^4.4",
-    "symfony/framework-bundle": "^3.3"
+    "symfony/dependency-injection": "^3.0 || ^4.0",
+    "symfony/config": "^3.0 || ^4.0",
+    "symfony/http-kernel": "^3.0 || ^4.0"
   },
   "require-dev": {
-      "contao/manager-plugin": "^2.0",
-      "doctrine/doctrine-cache-bundle": "^1.3",
-      "friendsofphp/php-cs-fixer": "^2.6",
-      "leofeyer/optimize-native-functions-fixer": "^1.1",
-      "php-http/guzzle6-adapter": "^1.1",
-      "php-http/message-factory": "^1.0.2",
-      "phpunit/phpunit": "^5.7.26",
-      "symfony/phpunit-bridge": "^3.2"
+    "contao/manager-plugin": "^2.0",
+    "friendsofphp/php-cs-fixer": "^2.6",
+    "phpunit/phpunit": "^5.7.26",
+    "symfony/phpunit-bridge": "^3.2"
   },
   "conflict": {
-		"contao/manager-plugin": "<2.0 || >=3.0"
-	},
+    "contao/manager-plugin": "<2.0 || >=3.0"
+  },
   "autoload": {
-		"psr-4": {
-			"Hschottm\\FaqExtensionsBundle\\": "src/"
-		},
+    "psr-4": {
+      "Hschottm\\FaqExtensionsBundle\\": "src/"
+    },
     "classmap": [
-          "src/Resources/contao/"
-  	    ],
-  	"exclude-from-classmap": [
-          "src/Resources/contao/config/",
-          "src/Resources/contao/dca/",
-          "src/Resources/contao/languages/",
-          "src/Resources/contao/templates/"
-  	    ]
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Hschottm\\FaqExtensionsBundle\\Tests\\": "tests/"
-        }
-    },
-    "extra":{
-      "contao-manager-plugin": "Hschottm\\FaqExtensionsBundle\\ContaoManager\\Plugin"
+      "src/Resources/contao/"
+    ],
+    "exclude-from-classmap": [
+      "src/Resources/contao/config/",
+      "src/Resources/contao/dca/",
+      "src/Resources/contao/languages/",
+      "src/Resources/contao/templates/"
+    ]
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Hschottm\\FaqExtensionsBundle\\Tests\\": "tests/"
     }
+  },
+  "extra":{
+    "contao-manager-plugin": "Hschottm\\FaqExtensionsBundle\\ContaoManager\\Plugin"
+  }
 }


### PR DESCRIPTION
This PR provides the following changes:

* Removed `symfony/framework-bundle` dependency, since no component of this bundle is actually used. This enables easier installation of the extension in Contao >4.4.
* Added missing dependencies of actually used components.
* Removed `leofeyer/optimize-native-functions-fixer` dev dependency since that is already integrated in the PHP CS Fixer.
* Removed unused dev dependencies.
* Fixed indentation.
* Change license notation to its official format.

Unrelated question: why do you have your own `ExceptionConverterListener`? Is there any specific reason for that? Otherwise you should just simply throw all the `Contao\CoreBundle\Exception\…` exceptions directly.